### PR TITLE
Pad line numbers instead of using a leading 0 under 10

### DIFF
--- a/line-numbers.css
+++ b/line-numbers.css
@@ -7,8 +7,11 @@ code span.line-number {
 }
 
 code span.line-number:before {
-  content: counter(line_numbers, decimal-leading-zero);
+  content: counter(line_numbers);
   color: gray;
+  text-align: center;
+  float: left;
+  width: 2ch;
 }
 
 code span.highlight-line:before {


### PR DESCRIPTION
This is an alternate solution to #1. I like it better, as I think the leading 0 looks odd. Example:

![indentation](https://cloud.githubusercontent.com/assets/700834/26030001/4ad79484-37f9-11e7-8937-280aae6ef011.png)

Feel free to discard this PR if you prefer leading 0's, but I thought I would at least propose it. Also note that we can make the numbers below 10 centered in the column or not, I have no strong preference.
