### PR TITLE
Fix leading space when highlighting and copying

### DIFF
--- a/line-numbers.css
+++ b/line-numbers.css
@@ -4,6 +4,7 @@ code.line-numbers {
 
 code span.line-number {
   counter-increment: line_numbers;
+  margin-right: 1em;
 }
 
 code span.line-number:before {

--- a/line-numbers.js
+++ b/line-numbers.js
@@ -59,7 +59,7 @@ function addLineNumbers() {
           classes += ' highlight-line';
         }
         // Append line with line number span.
-        content[n] = "<span class=\"" + classes + "\"> </span>" + content[n];
+        content[n] = "<span class=\"" + classes + "\"></span>" + content[n];
       }
       // Rejoin all content.
       content = content.join("\n");


### PR DESCRIPTION
When highlighting source code the span-element inserted for the line
numbers causes a leading white space to be selected for each line.
This commit fixes that by replacing the white space in the span-element
with a margin of 1em.