### PR TITLE
Fix line-numbers for Markdown-generated <pre><code> blocks.

### DIFF
--- a/line-numbers.js
+++ b/line-numbers.js
@@ -23,8 +23,38 @@ Reveal.addEventListener( 'ready', function( event ) {
 // Adding an event listener on slidechanged event to add line numbers to
 // code blocks.
 Reveal.addEventListener('slidechanged', function(event) {
+  addLineNumbersToPreCodeBlocks();
   addLineNumbers();
 });
+
+// Adds the "line-numbers" class and "data-highlight-lines" attribute to
+// <code> blocks enclosed in <pre> blocks.
+// (This is important for auto-generated HTML from Markdown, because
+// larger code-blocks will be enclosed in <pre><code>...</code></pre> blocks
+// by Markdown, but the "line-numbers" class will only be added to the <pre>
+// block.)
+function addLineNumbersToPreCodeBlocks() {
+  // For any <pre> blocks in the current slide with class 'line-numbers'.
+  var line_numbers = document.getElementsByClassName("line-numbers");
+  for (var l = 0; l < line_numbers.length; l++) {
+    if (line_numbers[l].tagName == "PRE") {
+      // Check if a <code> block is the only, single child.
+      if (line_numbers[l].hasChildNodes() && line_numbers[l].childNodes.length == 1 &&
+          line_numbers[l].firstChild.tagName == "CODE") {
+        // Check if <code> has line-number class not already applied.
+        var codeNode = line_numbers[l].firstChild;
+        if (! codeNode.classList.contains("line-numbers")) {
+          // Add 'line-numbers' class and possibly the attribute for lines to highlight.
+          codeNode.classList.add("line-numbers");
+          if (line_numbers[l].hasAttribute("data-highlight-lines")) {
+            attrValue = line_numbers[l].getAttribute("data-highlight-lines");
+            codeNode.setAttribute("data-highlight-lines", attrValue);
+          }
+        }
+      }
+    }
+  }
+}
 
 function addLineNumbers() {
   // For any code blocks in the current slide with class 'line-numbers'.


### PR DESCRIPTION
If generating HTML from Markdown using ` ``` ` code regions, the resulting code block will be enclosed in `<pre><code>...</code></pre>` HTML tags.
Sadly, using Reveal.js's annotation-mechanism does only apply classes and attributes to the outer `<pre>` tag.

For example, annotated Markdown code like this
````
```
This is line 1.
This is line 2.
```
<!-- .element class="line-numbers" -->
````
results in this
````
<pre class="line-numbers"><code>
This is line 1.
This is line 2.
</code></pre>
````
which does not show any line-numbers.

The current PR, however, transports this change to the inner `<code>` block, too, so that line-numbers can be displayed.